### PR TITLE
fix: simplify length comparisons in test_logging.py

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -296,7 +296,7 @@ async def test_shutdown_handler_logging(caplog: pytest.LogCaptureFixture) -> Non
         for record in caplog.records
         if record.levelname == "INFO" and "graceful shutdown" in record.message.lower()
     ]
-    assert len(shutdown_logs) >= 1, "Expected shutdown initiation log not found"
+    assert shutdown_logs, "Expected shutdown initiation log not found"
 
     # Check for worker stop log
     worker_stop_logs = [
@@ -305,7 +305,7 @@ async def test_shutdown_handler_logging(caplog: pytest.LogCaptureFixture) -> Non
         if record.levelname == "INFO"
         and "stopping consolidationworker" in record.message.lower()
     ]
-    assert len(worker_stop_logs) >= 1, "Expected worker stop log not found"
+    assert worker_stop_logs, "Expected worker stop log not found"
 
     # Check for background tasks stopped log
     tasks_stopped_logs = [
@@ -314,9 +314,7 @@ async def test_shutdown_handler_logging(caplog: pytest.LogCaptureFixture) -> Non
         if record.levelname == "INFO"
         and "background tasks stopped" in record.message.lower()
     ]
-    assert (
-        len(tasks_stopped_logs) >= 1
-    ), "Expected background tasks stopped log not found"
+    assert tasks_stopped_logs, "Expected background tasks stopped log not found"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
Simplifies length comparisons in test assertions by replacing `len(list) >= 1` with direct boolean evaluation.

## Changes
- Replace `assert len(shutdown_logs) >= 1` with `assert shutdown_logs`
- Replace `assert len(worker_stop_logs) >= 1` with `assert worker_stop_logs`
- Replace `assert len(tasks_stopped_logs) >= 1` with `assert tasks_stopped_logs`

## Benefits
- Improves code readability and follows PEP8 guidelines
- Adheres to KISS principle for cleaner test assertions
- Leverages Python's truthiness evaluation for sequences

## Code Quality
Fixes Sourcery code quality issue: `simplify-len-comparison`

## Testing
- [x] All existing tests pass
- [x] Code follows project standards (DRY, SRP, KISS)
- [x] Changes maintain semantic functionality

## Summary by Sourcery

Simplify length comparisons in test_logging.py by using direct truthiness checks instead of len(...) >= 1

Enhancements:
- Improve code readability by replacing len(seq) >= 1 with direct truthiness evaluation

Tests:
- Update test_shutdown_handler_logging to assert on list truthiness for shutdown, worker stop, and tasks stopped logs