### PR TITLE
Fix pre-commit hooks and apply ruff formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,7 @@ repos:
     hooks:
       - id: safety
         name: safety
-        entry: safety check --full-report
+        entry: safety scan --full-report
         language: system
         files: (requirements.*\.txt|pyproject\.toml)$
         pass_filenames: false

--- a/src/memory_gate/agent_interface.py
+++ b/src/memory_gate/agent_interface.py
@@ -123,9 +123,7 @@ class BaseMemoryEnabledAgent:
             record_agent_task_processed(
                 self.agent_name, self.domain.value, success=False
             )
-        except (
-            Exception
-        ) as e:  # pylint: disable=broad-except  # fallback for truly unexpected errors
+        except Exception as e:  # pylint: disable=broad-except  # fallback for truly unexpected errors
             task_failed_exception = e
             result_str = ERROR_MSG_UNEXPECTED_TASK_ERROR.format(error=e)
             confidence = 0.0

--- a/tests/metrics_recorder.py
+++ b/tests/metrics_recorder.py
@@ -228,7 +228,9 @@ class MetricsRecorder:
                     trend_symbol = (
                         "📈"
                         if current_vs_avg > 5
-                        else "📉" if current_vs_avg < -5 else "➡️"
+                        else "📉"
+                        if current_vs_avg < -5
+                        else "➡️"
                     )
                     report_sections.append(
                         f"  {trend_symbol} {name}: {self.format_duration(value)} (avg: {self.format_duration(stats['mean'])}, {current_vs_avg:+.1f}%)"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -155,9 +155,9 @@ async def test_main_module_logging(
         and expected_pattern.lower() in record.message.lower()
     ]
 
-    assert (
-        matching_records
-    ), f"Expected {log_level} log with pattern '{expected_pattern}' not found. Description: {description}. Available {log_level} logs: {[r.message for r in caplog.records if r.levelname.lower() == log_level.lower()]}"
+    assert matching_records, (
+        f"Expected {log_level} log with pattern '{expected_pattern}' not found. Description: {description}. Available {log_level} logs: {[r.message for r in caplog.records if r.levelname.lower() == log_level.lower()]}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -219,9 +219,9 @@ async def test_consolidation_logging(
         )
     ]
 
-    assert (
-        matching_records
-    ), f"Expected {log_level} log with pattern '{expected_pattern}' not found. Description: {description}. Available {log_level} logs: {[r.message for r in caplog.records if r.levelname.lower() == log_level.lower()]}"
+    assert matching_records, (
+        f"Expected {log_level} log with pattern '{expected_pattern}' not found. Description: {description}. Available {log_level} logs: {[r.message for r in caplog.records if r.levelname.lower() == log_level.lower()]}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -270,9 +270,9 @@ async def test_agent_interface_logging(
         and expected_pattern.lower() in record.message.lower()
     ]
 
-    assert (
-        matching_records
-    ), f"Expected {log_level} log with pattern '{expected_pattern}' not found. Description: {description}. Available {log_level} logs: {[r.message for r in caplog.records if r.levelname.lower() == log_level.lower()]}"
+    assert matching_records, (
+        f"Expected {log_level} log with pattern '{expected_pattern}' not found. Description: {description}. Available {log_level} logs: {[r.message for r in caplog.records if r.levelname.lower() == log_level.lower()]}"
+    )
 
 
 @pytest.mark.asyncio
@@ -368,9 +368,9 @@ async def test_agent_task_execution_logging_scenarios(
     assert confidence > 0, "Expected successful task execution"
 
     # Explicitly assert that no warning or error logs are present for successful execution
-    assert all(
-        record.levelno < logging.WARNING for record in caplog.records
-    ), "No warning or error logs should be present during successful learning"
+    assert all(record.levelno < logging.WARNING for record in caplog.records), (
+        "No warning or error logs should be present during successful learning"
+    )
 
     # Clear logs for next test
     caplog.clear()
@@ -395,9 +395,9 @@ async def test_agent_task_execution_logging_scenarios(
             and expected_message in record.message.lower()
         ]
 
-        assert (
-            matching_logs
-        ), f"Expected {expected_level} log with '{expected_message}' not found for {exception.__class__.__name__}"
+        assert matching_logs, (
+            f"Expected {expected_level} log with '{expected_message}' not found for {exception.__class__.__name__}"
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Changes
- Fixed deprecated safety check command to use `scan` instead of `check`
- Applied ruff formatting to resolve CI formatting issues in 3 files:
  - src/memory_gate/agent_interface.py
  - tests/metrics_recorder.py 
  - tests/test_logging.py
- Ensured pre-commit hooks work correctly for local development

## Impact
- Resolves CI failures related to ruff formatting
- Fixes deprecated safety command warnings
- Improves code consistency and readability

## Testing
All pre-commit hooks now pass successfully.

## Summary by Sourcery

Fix deprecated safety command, apply ruff formatting across code and tests to resolve CI issues, and ensure pre-commit hooks work correctly

Bug Fixes:
- Replace deprecated `safety check` command with `safety scan` in pre-commit configuration

Enhancements:
- Apply `ruff` formatting to source and test files to resolve CI formatting failures
- Simplify multi-line `assert` statements and conditional expressions for consistent style

Build:
- Update pre-commit configuration to restore hook execution

CI:
- Align codebase with `ruff` formatting rules to fix CI errors

Tests:
- Refactor assertion syntax in `test_logging.py`