### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,5 +108,5 @@ A dynamic memory learning layer for AI agents, designed for DevOps automation an
 
 - **Persistent Learning**: Enables AI agents to retain and build upon operational knowledge across sessions.
 - **Context-Aware Adaptation**: Dynamically adjusts responses based on accumulated experience patterns.
-- **Production Ready**: Designed for seamless deployment in containerized environments with proper monitoring and scaling.
+- **Cluster Focus**: Designed for seamless deployment in containerized environments with proper monitoring and scaling.
 - **DevOps Integration**: Provides native integration with existing CI/CD pipelines and infrastructure tools.


### PR DESCRIPTION
removed erroneous "production ready" statement

## Summary by Sourcery

Documentation:
- Rename the 'Production Ready' bullet to 'Cluster Focus' in README.md for accurate feature description.