### PR TITLE
ci: convert workflows to workflow_dispatch-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,8 @@
 name: Continuous Integration
 
+# Manual only — no push/pull_request CI triggers
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
-
+  workflow_dispatch:
 jobs:
   code-quality:
     name: Code Quality

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,11 +13,6 @@ on:
         required: false
         default: 'src tests'
         type: string
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
-
 jobs:
   lint:
     name: Code Quality Checks

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,14 +8,6 @@ on:
         required: false
         default: '3.13'
         type: string
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
-  schedule:
-    # Run security checks weekly on Mondays at 2 AM UTC
-    - cron: '0 2 * * 1'
-
 jobs:
   security:
     name: Security Checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,6 @@ on:
       coverage-percentage:
         description: 'Test coverage percentage'
         value: ${{ jobs.test.outputs.coverage }}
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
-
 jobs:
   test:
     name: Run Tests


### PR DESCRIPTION
Removes push/pull_request/schedule triggers from CI workflows. Entry workflow (ci.yml) is manual workflow_dispatch only; reusable workflows (lint, test, security) remain workflow_call-only.