### PR TITLE
chore(ci): add Commitizen manual check workflow

### DIFF
--- a/.github/workflows/commitizen.yml
+++ b/.github/workflows/commitizen.yml
@@ -1,0 +1,32 @@
+name: Commitizen
+
+# Commitizen CI Contract v1 — manual pre-release conventional commit verification
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cz-check:
+    name: Conventional Commits Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Verify conventional commits
+        run: uv run cz check --rev-range HEAD~1..HEAD

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ This setup supports:
 - **Linux**
 - **Dev Containers** for isolated development
 
+## Versioning
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/) and uses [Commitizen](https://commitizen-tools.github.io/commitizen/) for release versioning. Version is tracked in `pyproject.toml` (`project.version` and `[tool.commitizen]`). Before release, dispatch the **Commitizen** workflow (Actions → Commitizen → Run workflow) to verify commits on the current branch.
+
 ## Contact
 
 Tyler Zervas


### PR DESCRIPTION
## Summary

Adds a manual **Commitizen** GitHub Actions workflow so maintainers can verify conventional commits before release.

## Commitizen CI Contract v1

```yaml
# Commitizen CI Contract v1
trigger: workflow_dispatch only
job: cz-check
commands:
  python: uv run cz check --rev-range HEAD~1..HEAD  # on PR branches; or cz check for local
  rust: pip/uv install commitizen && cz check --rev-range HEAD~1..HEAD
version_files:
  python: pyproject.toml:project.version + [tool.commitizen]
  rust: .cz.toml + Cargo.toml:version
failure: non-conventional commits in PR fail the manual check
```

## Changes

- Add `.github/workflows/commitizen.yml` (`workflow_dispatch` only, job `cz-check`)
- Add README **Versioning** section (how to dispatch the workflow)
- Uses existing `commitizen` dev dependency via `uv sync --extra dev`

## Local validation

```bash
uv sync --extra dev
uv run cz check --rev-range HEAD~1..HEAD
```

Validated locally: `Commit validation: successful!`

## Notes

- No push/PR CI triggers added
- No application code or unrelated dependency changes