### PR TITLE
fix(security): CVE-2026-45829 chromadb mitigation (unpatched upstream)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,105 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Report security issues privately to **maintainers@vectorweight.com**. Do not open public
+issues for undisclosed vulnerabilities.
+
+Include: affected component, reproduction steps, impact assessment, and suggested fix if
+available. We aim to acknowledge reports within 5 business days.
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 0.1.x   | Yes       |
+
+## Known Vulnerabilities
+
+### CVE-2026-45829 — ChromaDB pre-authentication RCE (unpatched upstream)
+
+| Field | Value |
+| ----- | ----- |
+| **CVE** | [CVE-2026-45829](https://nvd.nist.gov/vuln/detail/CVE-2026-45829) |
+| **GHSA** | [GHSA-f4j7-r4q5-qw2c](https://github.com/advisories/GHSA-f4j7-r4q5-qw2c) |
+| **Severity** | CVSS 4.0 **10.0 CRITICAL** (HiddenLayer); CVSS 3.1 **10.0 CRITICAL** (Red Hat) |
+| **Affected package** | `chromadb` ≥ 1.0.0, ≤ 1.5.9 (all published PyPI releases as of 2026-07-15) |
+| **Pinned version** | `chromadb==1.5.9` (latest PyPI; **still vulnerable**) |
+| **Upstream tracker** | [chroma-core/chroma#6717](https://github.com/chroma-core/chroma/issues/6717) |
+| **Vendor patch** | **None** — no patched PyPI release available |
+
+#### Description
+
+A pre-authentication code-injection flaw in the ChromaDB Python server allows remote
+attackers to achieve arbitrary code execution by crafting a malicious embedding model
+configuration with `trust_remote_code=true` on the collection-creation API endpoint
+(`/api/v2/tenants/{tenant}/databases/{db}/collections`).
+
+A related client-SDK exposure exists when a Python client connects to a remote Chroma
+server and uses a collection whose server-side embedding configuration was poisoned
+(see [HiddenLayer research](https://www.hiddenlayer.com/research/chromatoast-served-pre-auth)).
+
+> **Status: unpatched upstream.** Memory-gate cannot eliminate this CVE via dependency
+> upgrade alone until Chroma publishes a fixed release.
+
+#### Memory-gate exposure assessment
+
+| Deployment mode | Exposure | Notes |
+| --------------- | -------- | ----- |
+| **Embedded client (default)** — `PersistentClient` / in-process `Client` | **Mitigated** | No Chroma HTTP server is started; RCE requires network-reachable Chroma server |
+| **Remote `HttpClient`** — `CHROMA_SERVER_HOST` set | **High** | Client may execute poisoned server-side embedding configs |
+| **Standalone Chroma server** — `chroma run` / Docker `chromadb/chroma` | **Critical** | Do **not** expose Python-backend Chroma to untrusted networks |
+
+Memory-gate's production code path uses **embedded client-only** storage via
+`VectorMemoryStore` (`src/memory_gate/storage/vector_store.py`), supplying its own
+`SentenceTransformer` embeddings and never calling `chromadb.HttpClient`.
+
+#### Implemented mitigations (defense-in-depth)
+
+1. **Dependency pin** — `chromadb` pinned to latest PyPI (`1.5.9`) in `pyproject.toml`
+   and `uv.lock`; `tool.uv.override-dependencies` prevents transitive downgrades.
+2. **Client-only architecture** — default deployment uses `PersistentClient`; remote
+   server mode is unsupported and must not be enabled without explicit risk acceptance.
+3. **Network binding guidance** — see [docs/security/chromadb-cve-2026-45829.md](docs/security/chromadb-cve-2026-45829.md) for bind-address, firewall, and Kubernetes `NetworkPolicy` requirements when operating any Chroma server alongside memory-gate.
+4. **Startup guard (optional)** — run `docs/security/chromadb_startup_guard.py` before
+   application start, or set `MEMORY_GATE_CHROMA_SERVER_WARN=1` to emit a critical log
+   when remote Chroma server environment variables are detected. Set
+   `MEMORY_GATE_ENFORCE_CLIENT_ONLY=1` to fail fast in CI/staging.
+5. **Metrics binding** — memory-gate binds Prometheus metrics to `127.0.0.1` by default
+   (`METRICS_HOST`); do not expose Chroma or metrics ports on `0.0.0.0` without auth.
+
+#### Residual risk (accepted)
+
+| Risk | Likelihood | Impact | Decision |
+| ---- | ---------- | ------ | -------- |
+| Embedded-client deployments (default Helm chart) | Low | Low | **Mitigated** — no network Chroma surface |
+| Operator enables `HttpClient` / external Chroma server | Medium | Critical | **Accepted with controls** — documented guard + network isolation required |
+| Future Chroma server bundled in chart | Low | Critical | **Blocked** — not supported until upstream patch ships |
+
+**Risk acceptance owner:** project maintainers  
+**Review cadence:** weekly until patched PyPI release  
+**Acceptance date:** 2026-07-15  
+**Expiry:** first business day after `chromadb` patched release ≥ 1.5.10 (or vendor advisory)
+
+#### Remediation timeline and monitoring
+
+| Milestone | Action |
+| --------- | ------ |
+| **Now** | Pin `chromadb==1.5.9`; enforce client-only defaults; document controls |
+| **Weekly** | Monitor [chroma#6717](https://github.com/chroma-core/chroma/issues/6717), [PyPI chromadb](https://pypi.org/project/chromadb/#history), [GHSA-f4j7-r4q5-qw2c](https://github.com/advisories/GHSA-f4j7-r4q5-qw2c) |
+| **On patch release** | Bump pin, run full regression suite, remove formal risk acceptance |
+| **Quarterly** | Re-audit deployment docs and Helm values for accidental server exposure |
+
+Subscribe to GitHub Dependabot alerts on this repository for automated `chromadb` bump PRs.
+
+## Dependency Security
+
+- Python 3.13 required (see `.python-version`).
+- Transitive dependency floors enforced via `[tool.uv.override-dependencies]` in
+  `pyproject.toml`.
+- Run `uv run safety check` (dev group) for local vulnerability scans.
+
+## Related Documentation
+
+- [ChromaDB CVE mitigation guide](docs/security/chromadb-cve-2026-45829.md)
+- [Optional startup guard script](docs/security/chromadb_startup_guard.py)

--- a/docs/security/chromadb-cve-2026-45829.md
+++ b/docs/security/chromadb-cve-2026-45829.md
@@ -1,0 +1,151 @@
+# ChromaDB CVE-2026-45829 — Deployment Mitigation Guide
+
+This document provides actionable controls for operators deploying memory-gate with the
+`storage` extra (`chromadb`).
+
+> **Unpatched upstream:** As of 2026-07-15, every `chromadb` release on PyPI through
+> **1.5.9** is affected. Upgrading within the 1.x line does not remediate the
+> vulnerability. See [SECURITY.md](../../SECURITY.md) for formal risk acceptance.
+
+## Vulnerability summary
+
+- **CVE:** CVE-2026-45829
+- **Attack vector:** Network — pre-authentication RCE on Chroma **Python** HTTP server
+- **Root cause:** Untrusted `trust_remote_code` in embedding-function configuration during
+  collection creation ([chroma#6717](https://github.com/chroma-core/chroma/issues/6717))
+- **Default Chroma server:** Rust backend (not affected by server-side Python RCE); the
+  Python backend is vulnerable when explicitly selected or when using the Python client SDK
+  against poisoned collections
+
+## Memory-gate default: client-only (recommended)
+
+Memory-gate uses embedded Chroma via `chromadb.PersistentClient`:
+
+```python
+# src/memory_gate/storage/vector_store.py (conceptual)
+chromadb.PersistentClient(path=persist_path, settings=Settings(...))
+```
+
+Characteristics:
+
+- No Chroma HTTP listener is started by memory-gate
+- Embeddings are generated locally with `sentence-transformers` (not server-side Chroma EF)
+- Data persists to a local directory (`CHROMA_PERSIST_DIRECTORY`)
+
+**Conclusion:** Standard memory-gate deployments are **not** running the vulnerable server
+endpoint. Residual risk is limited to misconfiguration (remote server mode) or compromise of
+the persistent data directory.
+
+### Environment variables (client-only defaults)
+
+| Variable | Default | Purpose |
+| -------- | ------- | ------- |
+| `CHROMA_PERSIST_DIRECTORY` | `./data/production_chromadb_store` | Local embedded store path |
+| `CHROMA_COLLECTION_NAME` | `memory_gate_prod_collection` | Collection name |
+| `METRICS_HOST` | `127.0.0.1` | Bind metrics to loopback |
+
+**Do not set** remote-server variables unless you have completed risk acceptance in
+[SECURITY.md](../../SECURITY.md):
+
+| Variable | Risk if set |
+| -------- | ----------- |
+| `CHROMA_SERVER_HOST` | Switches to `HttpClient` — poisoned-collection RCE |
+| `CHROMA_HTTP_HOST` / `CHROMA_HTTP_PORT` | Remote server connection |
+| `CHROMA_CLIENT_AUTH_PROVIDER` | Indicates authenticated remote mode (still risky pre-patch) |
+
+## Network binding restrictions
+
+If you operate a **separate** Chroma server (not recommended until patched):
+
+### Bind to loopback or private interfaces only
+
+```bash
+# Prefer Rust server (default in recent Chroma images)
+chroma run --path /data/chroma --host 127.0.0.1 --port 8000
+```
+
+Never bind Chroma to `0.0.0.0` on hosts reachable from untrusted networks.
+
+### Kubernetes
+
+```yaml
+# Deny all ingress to Chroma pods except from memory-gate namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: chroma-deny-external
+spec:
+  podSelector:
+    matchLabels:
+      app: chromadb
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: memory-gate
+      ports:
+        - protocol: TCP
+          port: 8000
+```
+
+### Firewall
+
+- Allow TCP 8000 (Chroma) only from memory-gate application subnets
+- Block WAN ingress entirely
+- Place Chroma in a private VPC segment with no public IP
+
+### Helm (memory-gate chart)
+
+The bundled chart uses **embedded** persistence (`persistence.mountPath`) and does not
+deploy a standalone Chroma server. Keep `service.type: ClusterIP` and `ingress.enabled: false`
+unless an API gateway with authentication terminates traffic.
+
+## Optional startup guard
+
+Run before application start in entrypoints, CI, or init containers:
+
+```bash
+uv run python docs/security/chromadb_startup_guard.py
+```
+
+Environment controls:
+
+| Variable | Behavior |
+| -------- | -------- |
+| `MEMORY_GATE_CHROMA_SERVER_WARN=1` | Log CRITICAL warning when remote Chroma env vars detected (default: enabled in script) |
+| `MEMORY_GATE_ENFORCE_CLIENT_ONLY=1` | Exit non-zero if remote server configuration detected |
+
+Example Docker/Kubernetes entrypoint wrapper:
+
+```bash
+#!/bin/sh
+set -e
+export MEMORY_GATE_ENFORCE_CLIENT_ONLY=1
+uv run python docs/security/chromadb_startup_guard.py
+exec uv run python -m memory_gate.main
+```
+
+## Alternative vector stores
+
+If Chroma server mode is required and risk acceptance is unacceptable, evaluate optional
+backends in the `storage` extra:
+
+- `qdrant-client` — Qdrant HTTP/gRPC client
+- `redis` — cache-oriented storage
+
+These are not drop-in replacements; migration planning is operator responsibility.
+
+## Monitoring checklist
+
+- [ ] Confirm `CHROMA_SERVER_HOST` is **unset** in production manifests
+- [ ] Verify no standalone `chromadb/chroma` Deployment exposes port 8000 publicly
+- [ ] Run startup guard in CI pipeline
+- [ ] Watch [chroma#6717](https://github.com/chroma-core/chroma/issues/6717) for patch release
+- [ ] Re-run `uv lock --upgrade-package chromadb` weekly; test before merge
+
+## References
+
+- [NVD CVE-2026-45829](https://nvd.nist.gov/vuln/detail/CVE-2026-45829)
+- [GHSA-f4j7-r4q5-qw2c](https://github.com/advisories/GHSA-f4j7-r4q5-qw2c)
+- [HiddenLayer: ChromaToast Served Pre-Auth](https://www.hiddenlayer.com/research/chromatoast-served-pre-auth)

--- a/docs/security/chromadb_startup_guard.py
+++ b/docs/security/chromadb_startup_guard.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Optional startup guard for ChromaDB CVE-2026-45829 (client-only enforcement).
+
+Invoke before starting memory-gate when remote Chroma server mode might be configured:
+
+    uv run python docs/security/chromadb_startup_guard.py
+
+Environment variables:
+    MEMORY_GATE_CHROMA_SERVER_WARN: Set to "0" to disable warnings (not recommended).
+    MEMORY_GATE_ENFORCE_CLIENT_ONLY: Set to "1" to exit with code 1 on remote-server signals.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+logger = logging.getLogger("memory_gate.security.chromadb")
+
+# Signals that memory-gate or Chroma may be configured for remote HTTP server mode.
+_REMOTE_CHROMA_ENV_VARS: tuple[str, ...] = (
+    "CHROMA_SERVER_HOST",
+    "CHROMA_HTTP_HOST",
+    "CHROMA_HTTP_PORT",
+    "CHROMA_HOST",
+    "CHROMA_PORT",
+    "CHROMA_CLIENT_AUTH_PROVIDER",
+    "CHROMA_CLIENT_AUTH_CREDENTIALS",
+)
+
+_CVE_REFERENCE = "CVE-2026-45829 (unpatched upstream; see SECURITY.md)"
+
+
+def _truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def detect_remote_chroma_configuration() -> list[str]:
+    """Return environment variable names indicating remote Chroma server usage."""
+    return [name for name in _REMOTE_CHROMA_ENV_VARS if os.getenv(name)]
+
+
+def emit_startup_warning(detected: list[str]) -> None:
+    """Log a critical warning when remote Chroma server configuration is present."""
+    if not detected:
+        logger.info(
+            "ChromaDB startup guard: embedded client-only configuration detected "
+            "(no remote server env vars). %s mitigations apply to server mode only.",
+            _CVE_REFERENCE,
+        )
+        return
+
+    logger.critical(
+        "ChromaDB REMOTE SERVER MODE detected via environment: %s. "
+        "%s allows pre-auth RCE on Python Chroma servers and client-side RCE via "
+        "poisoned collections. Memory-gate defaults to embedded PersistentClient; "
+        "unset these variables or complete formal risk acceptance (SECURITY.md).",
+        ", ".join(detected),
+        _CVE_REFERENCE,
+    )
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    warn_enabled = os.getenv("MEMORY_GATE_CHROMA_SERVER_WARN", "1")
+    enforce = _truthy(os.getenv("MEMORY_GATE_ENFORCE_CLIENT_ONLY"))
+
+    detected = detect_remote_chroma_configuration()
+
+    if _truthy(warn_enabled) or enforce:
+        emit_startup_warning(detected)
+
+    if enforce and detected:
+        logger.critical(
+            "MEMORY_GATE_ENFORCE_CLIENT_ONLY=1: refusing to start with remote Chroma "
+            "configuration."
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,9 @@ all = [
 
 [tool.uv]
 # Pin minimum secure versions for transitive dependencies surfaced by Dependabot.
+# chromadb==1.5.9 is latest PyPI but still affected by CVE-2026-45829 (no vendor patch).
 override-dependencies = [
+    "chromadb==1.5.9",
     "authlib>=1.6.12",
     "cryptography>=48.0.1",
     "filelock>=3.20.3",

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ resolution-markers = [
 [manifest]
 overrides = [
     { name = "authlib", specifier = ">=1.6.12" },
+    { name = "chromadb", specifier = "==1.5.9" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "filelock", specifier = ">=3.20.3" },
     { name = "h2", specifier = ">=4.3.0" },


### PR DESCRIPTION
## Summary

Mitigates **CVE-2026-45829** (Critical, CVSS 10.0) in `chromadb` through defense-in-depth controls and formal documentation. **No patched PyPI release exists** as of 2026-07-15; `chromadb==1.5.9` (latest) remains vulnerable.

> **unpatched upstream** — dependency pin alone does not remediate this CVE.

## Changes

- **SECURITY.md** — CVE scope, exposure assessment, mitigations, formal risk acceptance, monitoring timeline
- **docs/security/chromadb-cve-2026-45829.md** — operator guide: network binding, K8s NetworkPolicy, client-only defaults
- **docs/security/chromadb_startup_guard.py** — optional env-guard / startup warning for remote Chroma server configuration
- **pyproject.toml** — `chromadb==1.5.9` added to `[tool.uv.override-dependencies]`

## Triage

| Area | Status |
|------|--------|
| Default embedded `PersistentClient` deployment | **Mitigated** — no Chroma HTTP server surface |
| Remote `HttpClient` / standalone Chroma server | **Accepted risk** with documented controls |
| Dependency version | Pinned to latest PyPI (still vulnerable) |

## Residual risk

Operators who enable `CHROMA_SERVER_HOST` or deploy a network-exposed Python Chroma backend remain exposed until upstream ships a fix ([chroma#6717](https://github.com/chroma-core/chroma/issues/6717)). Weekly monitoring of PyPI and GHSA advised.

## Validation

```
uv sync --all-extras
uv run pytest --cov=src/memory_gate --cov-fail-under=83
# 76 passed, 83.45% coverage
```

No test or coverage-threshold changes.

## WS-9 scope

- No `tests/**` changes
- No `mycelium` changes
- No cov-fail-under changes