### PR TITLE
test: raise coverage gate to 85% with focused unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,7 +211,7 @@ addopts = [
     "--cov-report=term-missing:skip-covered",
     "--cov-report=html:htmlcov",
     "--cov-report=xml:coverage.xml",
-    "--cov-fail-under=83",
+    "--cov-fail-under=85",
     "--timeout=300",                        # 5 minute timeout for tests
     "--tb=short",                           # Short traceback format
     "-v",                                   # Verbose output

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,7 +10,7 @@ addopts =
     --cov-report=term-missing:skip-covered
     --cov-report=html
     --cov-report=xml
-    --cov-fail-under=83
+    --cov-fail-under=85
     -v
     --tb=short
     --durations=10

--- a/tests/test_agent_interface_unit.py
+++ b/tests/test_agent_interface_unit.py
@@ -1,0 +1,146 @@
+"""Unit tests for agent_interface uncovered paths."""
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from memory_gate.agent_interface import (
+    ERROR_MSG_EMPTY_AGENT_NAME,
+    ERROR_MSG_INVALID_AGENT_DOMAIN,
+    ERROR_MSG_INVALID_MEMORY_GATEWAY,
+    ERROR_MSG_SUBCLASS_MUST_IMPLEMENT,
+    AgentDomain,
+    BaseMemoryEnabledAgent,
+    SimpleEchoAgent,
+)
+from memory_gate.memory_gateway import MemoryGateway
+from memory_gate.memory_protocols import LearningContext, MemoryAdapter
+
+
+class PassThroughAdapter(MemoryAdapter[LearningContext]):
+    async def adapt_knowledge(
+        self, context: LearningContext, feedback: float | None = None
+    ) -> LearningContext:
+        return context
+
+
+def _make_gateway(
+    retrieve_results: list[LearningContext] | None = None,
+    learn_side_effect: Exception | None = None,
+) -> MemoryGateway[LearningContext]:
+    store = AsyncMock()
+    store.retrieve_context = AsyncMock(return_value=retrieve_results or [])
+    gateway = MemoryGateway(adapter=PassThroughAdapter(), store=store)
+    if learn_side_effect is not None:
+        gateway.learn_from_interaction = AsyncMock(side_effect=learn_side_effect)
+    else:
+        gateway.learn_from_interaction = AsyncMock()
+    return gateway
+
+
+class FailingAgent(BaseMemoryEnabledAgent):
+    def __init__(
+        self,
+        memory_gateway: MemoryGateway[LearningContext],
+        error: Exception,
+    ) -> None:
+        super().__init__(
+            agent_name="FailingAgent",
+            domain=AgentDomain.GENERAL,
+            memory_gateway=memory_gateway,
+        )
+        self._error = error
+
+    async def _execute_task(
+        self, enhanced_context: dict[str, Any]
+    ) -> tuple[str, float]:
+        raise self._error
+
+
+class TestBaseMemoryEnabledAgentValidation:
+    """Test constructor validation errors."""
+
+    def test_empty_agent_name_raises(self) -> None:
+        gateway = _make_gateway()
+        with pytest.raises(ValueError, match=ERROR_MSG_EMPTY_AGENT_NAME):
+            BaseMemoryEnabledAgent("", AgentDomain.GENERAL, gateway)
+
+    def test_invalid_domain_raises(self) -> None:
+        gateway = _make_gateway()
+        with pytest.raises(ValueError, match=ERROR_MSG_INVALID_AGENT_DOMAIN):
+            BaseMemoryEnabledAgent("Agent", "not-a-domain", gateway)  # type: ignore[arg-type]
+
+    def test_invalid_gateway_raises(self) -> None:
+        with pytest.raises(ValueError, match=ERROR_MSG_INVALID_MEMORY_GATEWAY):
+            BaseMemoryEnabledAgent("Agent", AgentDomain.GENERAL, MagicMock())  # type: ignore[arg-type]
+
+
+class TestBaseMemoryEnabledAgentExecution:
+    """Test task execution error and edge-case paths."""
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_during_task_records_failure(self) -> None:
+        gateway = _make_gateway()
+        agent = FailingAgent(gateway, RuntimeError("task boom"))
+        result, confidence = await agent.process_task("fail task")
+        assert "Error processing task" in result
+        assert confidence == 0.0
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_during_task(self) -> None:
+        gateway = _make_gateway()
+        agent = FailingAgent(gateway, Exception("unexpected"))
+        result, confidence = await agent.process_task("unexpected fail")
+        assert "Unexpected error processing task" in result
+        assert confidence == 0.0
+
+    @pytest.mark.asyncio
+    async def test_failure_without_storing_memory_reraises(self) -> None:
+        gateway = _make_gateway()
+        agent = FailingAgent(gateway, ValueError("no store"))
+        with pytest.raises(ValueError, match="no store"):
+            await agent.process_task("fail", store_interaction_memory=False)
+
+    @pytest.mark.asyncio
+    async def test_failure_summary_includes_failure_reason(self) -> None:
+        gateway = _make_gateway()
+        agent = FailingAgent(gateway, RuntimeError("disk full"))
+        await agent.process_task("disk issue", store_interaction_memory=True)
+        learned = gateway.learn_from_interaction.await_args
+        assert learned is not None
+        context = learned.args[0]
+        assert "FailureReason: disk full" in context.content
+
+    @pytest.mark.asyncio
+    async def test_execute_task_not_implemented(self) -> None:
+        gateway = _make_gateway()
+        agent = BaseMemoryEnabledAgent("Bare", AgentDomain.GENERAL, gateway)
+        with pytest.raises(NotImplementedError, match=ERROR_MSG_SUBCLASS_MUST_IMPLEMENT):
+            await agent._execute_task({"task_input": "x"})
+
+
+class TestSimpleEchoAgent:
+    """Test SimpleEchoAgent memory display paths."""
+
+    @pytest.mark.asyncio
+    async def test_echo_with_retrieved_memories_boosts_confidence(self) -> None:
+        memory = LearningContext(
+            content="Prior incident resolved by restart",
+            domain="general",
+            timestamp=datetime.now(),
+            importance=0.9,
+        )
+        gateway = _make_gateway(retrieve_results=[memory])
+        agent = SimpleEchoAgent(gateway)
+        result, confidence = await agent.process_task("check server")
+        assert "Retrieved memories:" in result
+        assert confidence == 0.6
+
+    def test_feedback_with_new_importance(self, capsys: pytest.CaptureFixture[str]) -> None:
+        gateway = _make_gateway()
+        agent = SimpleEchoAgent(gateway)
+        agent.provide_feedback_on_memory("key-1", 0.8, new_importance=0.95)
+        captured = capsys.readouterr()
+        assert "Suggested new importance: 0.95" in captured.out

--- a/tests/test_infrastructure_agent_unit.py
+++ b/tests/test_infrastructure_agent_unit.py
@@ -1,0 +1,93 @@
+"""Unit tests for infrastructure agent suggestion branches."""
+
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from memory_gate.agent_interface import AgentDomain
+from memory_gate.agents.infrastructure_agent import InfrastructureAgent
+from memory_gate.memory_gateway import MemoryGateway
+from memory_gate.memory_protocols import LearningContext, MemoryAdapter
+
+
+class PassThroughAdapter(MemoryAdapter[LearningContext]):
+    async def adapt_knowledge(
+        self, context: LearningContext, feedback: float | None = None
+    ) -> LearningContext:
+        return context
+
+
+class TestInfrastructureAgentBranches:
+    """Cover infrastructure agent suggestion code paths."""
+
+    @pytest.fixture
+    def infra_agent(self) -> InfrastructureAgent:
+        from unittest.mock import AsyncMock
+
+        store = AsyncMock()
+        gateway = MemoryGateway(adapter=PassThroughAdapter(), store=store)
+        return InfrastructureAgent(gateway)
+
+    @pytest.mark.asyncio
+    async def test_high_importance_with_solution_keyword(
+        self, infra_agent: InfrastructureAgent
+    ) -> None:
+        context = {
+            "task_input": "server alpha slow",
+            "retrieved_memories": [
+                {
+                    "content": "Task: alpha issue\nSolution: restart service",
+                    "importance": 0.9,
+                    "domain": AgentDomain.INFRASTRUCTURE.value,
+                    "timestamp": datetime.now().isoformat(),
+                    "metadata": {},
+                    "age_hours": 1.0,
+                }
+            ],
+        }
+        result, confidence = await infra_agent._execute_task(context)
+        assert "Suggestions based on past experiences" in result
+        assert confidence == 0.75
+
+    @pytest.mark.asyncio
+    async def test_keyword_match_without_solution(
+        self, infra_agent: InfrastructureAgent
+    ) -> None:
+        context = {
+            "task_input": "database latency spike",
+            "retrieved_memories": [
+                {
+                    "content": "database connection pool exhausted last week",
+                    "importance": 0.5,
+                    "domain": AgentDomain.INFRASTRUCTURE.value,
+                    "timestamp": datetime.now().isoformat(),
+                    "metadata": {},
+                    "age_hours": 2.0,
+                }
+            ],
+        }
+        result, confidence = await infra_agent._execute_task(context)
+        assert "Keyword match past event" in result
+        assert confidence == 0.75
+
+    @pytest.mark.asyncio
+    async def test_memories_found_but_not_relevant(
+        self, infra_agent: InfrastructureAgent
+    ) -> None:
+        context: dict[str, Any] = {
+            "task_input": "network latency spike",
+            "retrieved_memories": [
+                {
+                    "content": "storage alert on backup volume",
+                    "importance": 0.3,
+                    "domain": AgentDomain.INFRASTRUCTURE.value,
+                    "timestamp": datetime.now().isoformat(),
+                    "metadata": {},
+                    "age_hours": 3.0,
+                }
+            ],
+        }
+        result, confidence = await infra_agent._execute_task(context)
+        assert "none seem highly relevant" in result
+        assert confidence == 0.55

--- a/tests/test_main_extended.py
+++ b/tests/test_main_extended.py
@@ -1,0 +1,73 @@
+"""Extended unit tests for memory_gate.main uncovered paths."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from memory_gate.main import PassthroughAdapter, main, main_async
+from memory_gate.memory_protocols import LearningContext
+
+
+class TestPassthroughAdapter:
+    """Test PassthroughAdapter feedback handling."""
+
+    @pytest.mark.asyncio
+    async def test_adapt_with_normalized_feedback(self) -> None:
+        adapter = PassthroughAdapter()
+        context = LearningContext(
+            content="test",
+            domain="general",
+            timestamp=__import__("datetime").datetime.now(),
+            importance=0.8,
+        )
+        result = await adapter.adapt_knowledge(context, feedback=0.6)
+        assert result.importance == pytest.approx(0.7)
+
+    @pytest.mark.asyncio
+    async def test_adapt_with_out_of_range_feedback(self) -> None:
+        adapter = PassthroughAdapter()
+        context = LearningContext(
+            content="test",
+            domain="general",
+            timestamp=__import__("datetime").datetime.now(),
+            importance=0.8,
+        )
+        result = await adapter.adapt_knowledge(context, feedback=1.5)
+        assert result.importance == 1.5
+
+
+class TestMainAsyncPaths:
+    """Test main_async branches not covered by existing tests."""
+
+    @pytest.mark.asyncio
+    @patch("memory_gate.main.VectorMemoryStore")
+    @patch("memory_gate.main.start_metrics_server")
+    @patch("asyncio.sleep", side_effect=asyncio.CancelledError())
+    async def test_main_async_consolidation_disabled(
+        self,
+        mock_sleep: MagicMock,
+        mock_start_metrics: MagicMock,
+        mock_vector_store: MagicMock,
+    ) -> None:
+        mock_vector_store.return_value = AsyncMock()
+        with patch("memory_gate.main.CONSOLIDATION_ENABLED", new=False):
+            await main_async()
+        mock_start_metrics.assert_called_once()
+
+
+class TestMainEntrypoint:
+    """Test synchronous main() entrypoint."""
+
+    @patch("memory_gate.main.asyncio.get_event_loop")
+    def test_main_keyboard_interrupt(self, mock_get_loop: MagicMock) -> None:
+        loop = MagicMock()
+        main_task = MagicMock()
+        main_task.done.return_value = False
+        loop.create_task.return_value = main_task
+        loop.run_until_complete.side_effect = KeyboardInterrupt()
+        mock_get_loop.return_value = loop
+
+        main()
+
+        main_task.cancel.assert_called_once()

--- a/tests/test_metrics_module.py
+++ b/tests/test_metrics_module.py
@@ -1,0 +1,73 @@
+"""Unit tests for memory_gate.metrics Prometheus helpers."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from memory_gate.metrics import (
+    _should_include_exception_info,
+    record_agent_memory_learned,
+    record_agent_task_processed,
+    record_consolidation_items_processed,
+    record_consolidation_run,
+    record_memory_operation,
+    start_metrics_server,
+)
+
+
+class TestMetricsHelpers:
+    """Test metric recording helper functions."""
+
+    def test_record_memory_operation_success(self) -> None:
+        record_memory_operation("store_experience", success=True)
+        record_memory_operation("retrieve_context", success=False)
+
+    def test_record_consolidation_helpers(self) -> None:
+        record_consolidation_run(success=True)
+        record_consolidation_run(success=False)
+        record_consolidation_items_processed(3, action="deleted")
+
+    def test_record_agent_helpers(self) -> None:
+        record_agent_task_processed("TestAgent", "general", success=True)
+        record_agent_task_processed("TestAgent", "general", success=False)
+        record_agent_memory_learned("TestAgent", "general")
+
+
+class TestStartMetricsServer:
+    """Test Prometheus metrics server startup."""
+
+    @patch("memory_gate.metrics.start_http_server")
+    def test_start_metrics_server_success(self, mock_start: MagicMock) -> None:
+        start_metrics_server(port=18008, addr="127.0.0.1")
+        mock_start.assert_called_once()
+
+    @patch("memory_gate.metrics.start_http_server", side_effect=OSError("port in use"))
+    def test_start_metrics_server_failure(
+        self, mock_start: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.ERROR):
+            start_metrics_server(port=18009, addr="127.0.0.1")
+        assert mock_start.called
+        assert any("Prometheus metrics server" in r.message for r in caplog.records)
+
+    @patch("memory_gate.metrics.start_http_server", side_effect=OSError("port in use"))
+    def test_start_metrics_server_failure_debug_logging(
+        self, mock_start: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.DEBUG):
+            start_metrics_server(port=18010, addr="127.0.0.1")
+        assert mock_start.called
+
+
+class TestShouldIncludeExceptionInfo:
+    """Test exception info logging helper."""
+
+    def test_returns_false_when_debug_disabled(self) -> None:
+        assert _should_include_exception_info() is False
+
+    def test_returns_true_when_debug_enabled(self) -> None:
+        test_logger = logging.getLogger("memory_gate.metrics.test")
+        with patch.object(test_logger, "isEnabledFor", return_value=True):
+            with patch("memory_gate.metrics.logger", test_logger):
+                assert _should_include_exception_info() is True

--- a/tests/test_vector_store_unit.py
+++ b/tests/test_vector_store_unit.py
@@ -1,0 +1,226 @@
+"""Unit tests for vector_store uncovered paths."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+from memory_gate.memory_protocols import LearningContext
+from memory_gate.storage.vector_store import (
+    ChromaDBMetadata,
+    VectorMemoryStore,
+    VectorStoreConfig,
+    VectorStoreError,
+    VectorStoreInitError,
+    VectorStoreOperationError,
+)
+
+
+class TestChromaDBMetadata:
+    """Test ChromaDBMetadata validation helpers."""
+
+    def test_valid_metadata(self) -> None:
+        meta = ChromaDBMetadata(
+            domain="infra",
+            timestamp=datetime.now().isoformat(),
+            importance=0.5,
+            custom_field="value",
+        )
+        filtered = meta.to_filtered_dict()
+        assert "custom_field" in filtered
+        assert "domain" not in filtered
+
+    def test_invalid_timestamp_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid timestamp format"):
+            ChromaDBMetadata(timestamp="not-a-date")
+
+    def test_invalid_importance_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid importance value"):
+            ChromaDBMetadata(timestamp=datetime.now().isoformat(), importance="bad")  # type: ignore[arg-type]
+
+
+class TestVectorStoreExceptions:
+    """Test custom exception classes."""
+
+    def test_vector_store_error(self) -> None:
+        err = VectorStoreError("base error")
+        assert err.message == "base error"
+
+    def test_vector_store_init_error(self) -> None:
+        err = VectorStoreInitError("init failed")
+        assert err.message == "init failed"
+
+    def test_vector_store_operation_error(self) -> None:
+        err = VectorStoreOperationError("op failed")
+        assert err.message == "op failed"
+
+
+class TestVectorStoreInitFailures:
+    """Test initialization error paths."""
+
+    def test_chromadb_init_failure(self) -> None:
+        config = VectorStoreConfig(collection_name="fail", persist_directory="/tmp/x")
+        with patch(
+            "memory_gate.storage.vector_store.chromadb.PersistentClient",
+            side_effect=RuntimeError("chroma down"),
+        ):
+            with pytest.raises(VectorStoreInitError, match="Failed to initialize ChromaDB"):
+                VectorMemoryStore(config=config)
+
+    def test_embedding_model_init_failure(self) -> None:
+        config = VectorStoreConfig(collection_name="fail", persist_directory=None)
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection.return_value = MagicMock()
+        with (
+            patch("memory_gate.storage.vector_store.chromadb.Client", return_value=mock_client),
+            patch(
+                "memory_gate.storage.vector_store.SentenceTransformer",
+                side_effect=RuntimeError("model missing"),
+            ),
+        ):
+            with pytest.raises(VectorStoreInitError, match="Failed to initialize embedding model"):
+                VectorMemoryStore(config=config)
+
+
+@pytest.fixture
+def mocked_vector_store() -> VectorMemoryStore:
+    """Vector store with mocked ChromaDB and embedding model."""
+    config = VectorStoreConfig(
+        collection_name="unit_test_collection",
+        persist_directory=None,
+    )
+    mock_collection = MagicMock()
+    mock_collection.count.return_value = 0
+    mock_client = MagicMock()
+    mock_client.get_or_create_collection.return_value = mock_collection
+    mock_model = MagicMock()
+    mock_model.encode.return_value = np.array([0.1, 0.2, 0.3])
+
+    with (
+        patch("memory_gate.storage.vector_store.chromadb.Client", return_value=mock_client),
+        patch(
+            "memory_gate.storage.vector_store.SentenceTransformer",
+            return_value=mock_model,
+        ),
+    ):
+        store = VectorMemoryStore(config=config)
+    store.collection = mock_collection
+    store.embedding_model = mock_model
+    return store
+
+
+class TestVectorStoreOperations:
+    """Test vector store operation branches with mocks."""
+
+    def test_validate_query_results_invalid(self, mocked_vector_store: VectorMemoryStore) -> None:
+        assert mocked_vector_store._validate_query_results({}) is False
+        assert mocked_vector_store._validate_query_results({"ids": [[]]}) is False
+
+    def test_parse_metadata_fallback(self, mocked_vector_store: VectorMemoryStore) -> None:
+        context = mocked_vector_store._parse_metadata(
+            "id-1",
+            {"timestamp": "invalid", "domain": "test"},
+            "document body",
+        )
+        assert context.domain == "unknown"
+        assert context.content == "document body"
+
+    @pytest.mark.asyncio
+    async def test_store_experience_failure(
+        self, mocked_vector_store: VectorMemoryStore
+    ) -> None:
+        mocked_vector_store.collection.upsert.side_effect = RuntimeError("upsert failed")
+        context = LearningContext(
+            content="fail store",
+            domain="test",
+            timestamp=datetime.now(),
+        )
+        with pytest.raises(RuntimeError, match="upsert failed"):
+            await mocked_vector_store.store_experience("key", context)
+
+    @pytest.mark.asyncio
+    async def test_retrieve_with_filters(
+        self, mocked_vector_store: VectorMemoryStore
+    ) -> None:
+        ts = datetime.now().isoformat()
+        mocked_vector_store.collection.query.return_value = {
+            "ids": [["id-1"]],
+            "documents": [["filtered doc"]],
+            "metadatas": [[{"domain": "infra", "timestamp": ts, "importance": 0.7}]],
+        }
+        results = await mocked_vector_store.retrieve_context(
+            query="search",
+            domain_filter="infra",
+            metadata_filter={"importance": {"$gte": 0.5}},
+        )
+        assert len(results) == 1
+        assert results[0].domain == "infra"
+
+    @pytest.mark.asyncio
+    async def test_retrieve_invalid_results_returns_empty(
+        self, mocked_vector_store: VectorMemoryStore
+    ) -> None:
+        mocked_vector_store.collection.query.return_value = {"ids": [[]]}
+        results = await mocked_vector_store.retrieve_context(query="empty")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_retrieve_failure_raises(
+        self, mocked_vector_store: VectorMemoryStore
+    ) -> None:
+        mocked_vector_store.collection.query.side_effect = RuntimeError("query failed")
+        with pytest.raises(RuntimeError, match="query failed"):
+            await mocked_vector_store.retrieve_context(query="boom")
+
+    @pytest.mark.asyncio
+    async def test_get_experience_missing_documents(
+        self, mocked_vector_store: VectorMemoryStore
+    ) -> None:
+        mocked_vector_store.collection.get.return_value = {
+            "ids": ["id-1"],
+            "documents": [],
+            "metadatas": [],
+        }
+        result = await mocked_vector_store.get_experience_by_id("id-1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_experience_failure_raises(
+        self, mocked_vector_store: VectorMemoryStore
+    ) -> None:
+        mocked_vector_store.collection.get.side_effect = RuntimeError("get failed")
+        with pytest.raises(RuntimeError, match="get failed"):
+            await mocked_vector_store.get_experience_by_id("id-1")
+
+    @pytest.mark.asyncio
+    async def test_delete_experience_failure(
+        self, mocked_vector_store: VectorMemoryStore
+    ) -> None:
+        mocked_vector_store.collection.delete.side_effect = RuntimeError("delete failed")
+        with pytest.raises(RuntimeError, match="delete failed"):
+            await mocked_vector_store.delete_experience("id-1")
+
+    @pytest.mark.asyncio
+    async def test_get_experiences_by_metadata_filter(
+        self, mocked_vector_store: VectorMemoryStore
+    ) -> None:
+        ts = datetime.now().isoformat()
+        mocked_vector_store.collection.get.return_value = {
+            "ids": ["id-1"],
+            "documents": ["doc"],
+            "metadatas": [{"domain": "infra", "timestamp": ts, "importance": 0.2}],
+        }
+        items = await mocked_vector_store.get_experiences_by_metadata_filter(
+            {"importance": {"$lt": 0.5}}
+        )
+        assert len(items) == 1
+        assert items[0][0] == "id-1"
+
+    @pytest.mark.asyncio
+    async def test_get_experiences_by_metadata_filter_failure(
+        self, mocked_vector_store: VectorMemoryStore
+    ) -> None:
+        mocked_vector_store.collection.get.side_effect = RuntimeError("filter failed")
+        with pytest.raises(RuntimeError, match="filter failed"):
+            await mocked_vector_store.get_experiences_by_metadata_filter({"domain": "x"})


### PR DESCRIPTION
## Summary
Raises enforced test coverage from **83% → 97.56%** (gate set to **85%**) by adding focused unit tests for previously uncovered paths in `agent_interface`, `vector_store`, `metrics`, `main`, and `infrastructure_agent`.

## Coverage
| Metric | Before | After |
|--------|--------|-------|
| Total  | 83%    | **97.56%** |
| Gate   | 83     | **85** |

### Remaining uncovered (non-blocking)
- `memory_protocols.py` Protocol ellipsis stubs (13, 21, 27)
- `consolidation.py` TYPE_CHECKING import + edge pagination guard
- Minor branches in `vector_store.py` / `infrastructure_agent.py`

## New tests
- `tests/test_metrics_module.py` — Prometheus helpers, `start_metrics_server` success/failure, `_should_include_exception_info`
- `tests/test_agent_interface_unit.py` — constructor validation, task failure paths, echo-agent memory branch
- `tests/test_main_extended.py` — `PassthroughAdapter` feedback, consolidation-disabled path, `main()` KeyboardInterrupt
- `tests/test_vector_store_unit.py` — metadata validation, init failures, mocked operation error paths & filters
- `tests/test_infrastructure_agent_unit.py` — suggestion branches (solution keyword, keyword match, low relevance)

## Validation
```bash
uv python pin 3.13 && uv sync --extra dev --extra storage
uv run pytest --cov=src/memory_gate --cov-fail-under=85
```

```
Required test coverage of 85% reached. Total coverage: 97.56%
================== 120 passed, 8 warnings in 80.42s (0:01:20) ==================
```

## Dependency files
- [x] No changes to `[project.dependencies]`, `[tool.uv]`, or `uv.lock`
- Only `pytest.ini` / `[tool.pytest.ini_options]` cov threshold updated