### PR TITLE
feat(embedding): shared multi-model catalog aligned with memory-gate-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ Tyler Zervas
 
 A dynamic memory learning layer for AI agents, designed for DevOps automation and homelab AI R&D.
 
+## Supported embedding models
+
+`VectorStoreConfig.embedding_model_name` accepts a **stable catalog ID** (shared with [memory-gate-rs](https://github.com/tzervas/memory-gate-rs)) or the SentenceTransformers / Hugging Face load name. Default remains `all-MiniLM-L6-v2` for existing deployments; cross-port parity experiments should pin `all-minilm-l6-v2`.
+
+| Stable ID | SentenceTransformers / HF | Dim |
+|-----------|---------------------------|-----|
+| `all-minilm-l6-v2` | `all-MiniLM-L6-v2` | 384 |
+| `bge-small-en-v1.5` | `BAAI/bge-small-en-v1.5` | 384 |
+| `bge-base-en-v1.5` | `BAAI/bge-base-en-v1.5` | 768 |
+
+Resolve programmatically via `memory_gate.embedding_catalog.resolve_model(id)`.
+
 ## Key Features
 
 - **Persistent Learning**: Enables AI agents to retain and build upon operational knowledge across sessions.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,18 @@ A dynamic memory learning layer for AI agents, designed for DevOps automation an
 
 ## Supported embedding models
 
-`VectorStoreConfig.embedding_model_name` accepts a **stable catalog ID** (shared with [memory-gate-rs](https://github.com/tzervas/memory-gate-rs)) or the SentenceTransformers / Hugging Face load name. Default remains `all-MiniLM-L6-v2` for existing deployments; cross-port parity experiments should pin `all-minilm-l6-v2`.
+`VectorStoreConfig.embedding_model_name` accepts a **stable catalog ID** (shared with [memory-gate-rs](https://github.com/tzervas/memory-gate-rs)) or a **catalog-listed** SentenceTransformers / Hugging Face load name. Off-catalog model strings are rejected at init. Default remains `all-MiniLM-L6-v2` for existing deployments; cross-port parity experiments should pin `all-minilm-l6-v2`.
+
+### One collection per embedding model
+
+Each Chroma collection is bound to exactly one catalog model and dimension. On `VectorMemoryStore` init, collection metadata is stamped (or validated):
+
+| Metadata key | Value |
+|--------------|-------|
+| `memory_gate_embedding_model` | Stable catalog ID (e.g. `all-minilm-l6-v2`) |
+| `memory_gate_embedding_dim` | Embedding dimension as a string (e.g. `384`) |
+
+If an existing collection was created with a different model or dimension, initialization fails with `VectorStoreInitError`. Legacy collections that already contain vectors but lack these keys also fail closed—use a new `collection_name` or migrate. Empty collections without stamps are updated automatically. User experience metadata cannot override binding: keys prefixed with `memory_gate_` or `embedding_` are stripped on store.
 
 | Stable ID | SentenceTransformers / HF | Dim |
 |-----------|---------------------------|-----|

--- a/src/memory_gate/__init__.py
+++ b/src/memory_gate/__init__.py
@@ -4,6 +4,7 @@ import logging
 
 from . import agents  # Import the agents submodule
 from .agent_interface import AgentDomain, BaseMemoryEnabledAgent, SimpleEchoAgent
+from .embedding_catalog import CatalogEntry, resolve_model
 from .memory_gateway import MemoryGateway
 from .memory_protocols import KnowledgeStore, LearningContext, MemoryAdapter
 
@@ -18,10 +19,12 @@ logging.basicConfig(
 __all__ = [
     "AgentDomain",
     "BaseMemoryEnabledAgent",
+    "CatalogEntry",
     "KnowledgeStore",
     "LearningContext",
     "MemoryAdapter",
     "MemoryGateway",
     "SimpleEchoAgent",
     "agents",
+    "resolve_model",
 ]

--- a/src/memory_gate/embedding_catalog.py
+++ b/src/memory_gate/embedding_catalog.py
@@ -1,0 +1,65 @@
+"""Shared embedding model catalog aligned with memory-gate-rs (mg/embed-catalog@STABLE)."""
+
+from dataclasses import dataclass
+
+# Stable catalog entries: id -> (sentence_transformers_load_name, dimension)
+_CATALOG: dict[str, tuple[str, int]] = {
+    "all-minilm-l6-v2": ("all-MiniLM-L6-v2", 384),
+    "bge-small-en-v1.5": ("BAAI/bge-small-en-v1.5", 384),
+    "bge-base-en-v1.5": ("BAAI/bge-base-en-v1.5", 768),
+}
+
+SUPPORTED_STABLE_IDS: tuple[str, ...] = tuple(_CATALOG.keys())
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogEntry:
+    """Resolved embedding model from the shared catalog."""
+
+    stable_id: str
+    st_name: str
+    dimension: int
+
+
+def _normalize_key(name: str) -> str:
+    normalized = name.strip().lower()
+    stripped = normalized.removeprefix("sentence-transformers/")
+    if stripped.startswith("baai/"):
+        stripped = stripped[len("baai/") :]
+    return stripped
+
+
+def resolve_model(name: str) -> CatalogEntry:
+    """Resolve a stable ID, SentenceTransformers name, or alias to a catalog entry.
+
+    Args:
+        name: Catalog stable ID, HF/ST load name, or short alias (case-insensitive).
+
+    Returns:
+        CatalogEntry with stable_id, st_name, and dimension.
+
+    Raises:
+        ValueError: If the name is not in the catalog, with supported stable IDs listed.
+    """
+    key = _normalize_key(name)
+
+    stable_id: str | None = key if key in _CATALOG else None
+    if stable_id is None:
+        match key:
+            case "allminilml6v2" | "minilm" | "minilm-l6":
+                stable_id = "all-minilm-l6-v2"
+            case "bgesmallenv15" | "bge-small" | "bge_small_en_v1.5":
+                stable_id = "bge-small-en-v1.5"
+            case "bgebaseenv15" | "bge-base" | "bge_base_en_v1.5":
+                stable_id = "bge-base-en-v1.5"
+            case _:
+                stable_id = None
+
+    if stable_id is None:
+        supported = ", ".join(SUPPORTED_STABLE_IDS)
+        raise ValueError(
+            f"unknown embedding model '{name}'; supported stable IDs: {supported}"
+        )
+
+    st_name, dimension = _CATALOG[stable_id]
+    return CatalogEntry(stable_id=stable_id, st_name=st_name, dimension=dimension)

--- a/src/memory_gate/storage/vector_store.py
+++ b/src/memory_gate/storage/vector_store.py
@@ -32,6 +32,16 @@ logger = logging.getLogger(__name__)
 ERROR_MSG_CHROMADB_INIT_FAILED = "Failed to initialize ChromaDB client: {error}"
 ERROR_MSG_EMBEDDING_MODEL_INIT_FAILED = "Failed to initialize embedding model: {error}"
 
+# Chroma collection metadata keys (string values only)
+MEMORY_GATE_EMBEDDING_MODEL_KEY = "memory_gate_embedding_model"
+MEMORY_GATE_EMBEDDING_DIM_KEY = "memory_gate_embedding_dim"
+
+# Reserved prefixes stripped from user-supplied experience metadata before Chroma upsert
+_RESERVED_EXPERIENCE_METADATA_PREFIXES = ("memory_gate_",)
+_RESERVED_EXPERIENCE_METADATA_EXACT = frozenset(
+    {MEMORY_GATE_EMBEDDING_MODEL_KEY, MEMORY_GATE_EMBEDDING_DIM_KEY}
+)
+
 
 class ChromaDBMetadata(BaseModel):
     """Pydantic model for validating ChromaDB metadata.
@@ -149,6 +159,15 @@ class VectorMemoryStore(KnowledgeStore[LearningContext]):
         self.config = config
 
         try:
+            catalog_entry = resolve_model(self.config.embedding_model_name)
+        except ValueError as e:
+            raise VectorStoreInitError(str(e)) from e
+
+        self.embedding_model_stable_id = catalog_entry.stable_id
+        self.embedding_st_name = catalog_entry.st_name
+        self.embedding_dimension = catalog_entry.dimension
+
+        try:
             if self.config.persist_directory:
                 # Ensure persist_directory is a string for ChromaDB 1.0.13+
                 persist_path = str(Path(self.config.persist_directory).resolve())
@@ -175,15 +194,6 @@ class VectorMemoryStore(KnowledgeStore[LearningContext]):
             raise VectorStoreInitError(msg) from e
 
         try:
-            catalog_entry = resolve_model(self.config.embedding_model_name)
-        except ValueError as e:
-            raise VectorStoreInitError(str(e)) from e
-
-        self.embedding_model_stable_id = catalog_entry.stable_id
-        self.embedding_st_name = catalog_entry.st_name
-        self.embedding_dimension = catalog_entry.dimension
-
-        try:
             self.embedding_model = SentenceTransformer(
                 catalog_entry.st_name, device=self.config.embedding_device
             )
@@ -191,17 +201,86 @@ class VectorMemoryStore(KnowledgeStore[LearningContext]):
             msg = ERROR_MSG_EMBEDDING_MODEL_INIT_FAILED.format(error=e)
             raise VectorStoreInitError(msg) from e
 
+        collection_metadata = self._build_collection_metadata()
         self.collection = self.client.get_or_create_collection(
             name=self.config.collection_name,
-            metadata=self.config.collection_metadata
-            or {"description": "MemoryGate learning storage"},
+            metadata=collection_metadata,
         )
+        self._ensure_collection_embedding_binding()
         # Initialize item count gauge
         MEMORY_ITEMS_COUNT.labels(
             store_type="vector_store", collection_name=self.config.collection_name
         ).set_function(
             lambda: self.collection.count()  # Periodically update with current count
         )
+
+    def _build_collection_metadata(self) -> dict[str, str]:
+        """Merge user collection metadata with required embedding binding stamps."""
+        user_meta = dict(self.config.collection_metadata or {})
+        user_meta.pop(MEMORY_GATE_EMBEDDING_MODEL_KEY, None)
+        user_meta.pop(MEMORY_GATE_EMBEDDING_DIM_KEY, None)
+        if not user_meta:
+            user_meta = {"description": "MemoryGate learning storage"}
+        stamps = {
+            MEMORY_GATE_EMBEDDING_MODEL_KEY: self.embedding_model_stable_id,
+            MEMORY_GATE_EMBEDDING_DIM_KEY: str(self.embedding_dimension),
+        }
+        return {k: str(v) for k, v in {**user_meta, **stamps}.items()}
+
+    def _ensure_collection_embedding_binding(self) -> None:
+        """Validate or stamp Chroma collection embedding model metadata (fail closed)."""
+        meta = dict(self.collection.metadata or {})
+        stored_model = meta.get(MEMORY_GATE_EMBEDDING_MODEL_KEY)
+        stored_dim = meta.get(MEMORY_GATE_EMBEDDING_DIM_KEY)
+        expected_model = self.embedding_model_stable_id
+        expected_dim = str(self.embedding_dimension)
+
+        if stored_model is not None or stored_dim is not None:
+            if stored_model != expected_model or stored_dim != expected_dim:
+                msg = (
+                    "Chroma collection embedding binding mismatch: "
+                    f"collection has model={stored_model!r} dim={stored_dim!r}, "
+                    f"requested model={expected_model!r} dim={expected_dim!r}. "
+                    "Use a different collection_name or migrate data; "
+                    "one embedding model per collection is required."
+                )
+                raise VectorStoreInitError(msg)
+            return
+
+        item_count = self.collection.count()
+        if item_count > 0:
+            msg = (
+                "Chroma collection has no memory_gate embedding metadata but "
+                f"contains {item_count} item(s). "
+                "Create a new collection name or run a migration before switching "
+                "embedding models."
+            )
+            raise VectorStoreInitError(msg)
+
+        stamped = {
+            **{k: str(v) for k, v in meta.items()},
+            MEMORY_GATE_EMBEDDING_MODEL_KEY: expected_model,
+            MEMORY_GATE_EMBEDDING_DIM_KEY: expected_dim,
+        }
+        self.collection.modify(metadata=stamped)
+
+    @staticmethod
+    def _filter_experience_metadata(
+        metadata: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Drop reserved keys so user metadata cannot spoof collection binding."""
+        if not metadata:
+            return {}
+        filtered: dict[str, Any] = {}
+        for key, value in metadata.items():
+            if key in _RESERVED_EXPERIENCE_METADATA_EXACT:
+                continue
+            if key.startswith(_RESERVED_EXPERIENCE_METADATA_PREFIXES):
+                continue
+            if key.startswith("embedding_"):
+                continue
+            filtered[key] = value
+        return filtered
 
     def _validate_query_results(self, query_results: dict[str, Any]) -> bool:
         """Validate that query results contain the expected structure.
@@ -319,7 +398,7 @@ class VectorMemoryStore(KnowledgeStore[LearningContext]):
                     "domain": experience.domain,
                     "timestamp": experience.timestamp.isoformat(),
                     "importance": experience.importance,
-                    **(experience.metadata or {}),
+                    **self._filter_experience_metadata(experience.metadata),
                 }
 
                 # Convert embeddings to sequence for ChromaDB

--- a/src/memory_gate/storage/vector_store.py
+++ b/src/memory_gate/storage/vector_store.py
@@ -11,6 +11,7 @@ import numpy as np
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sentence_transformers import SentenceTransformer
 
+from memory_gate.embedding_catalog import resolve_model
 from memory_gate.memory_protocols import KnowledgeStore, LearningContext
 from memory_gate.metrics import (
     MEMORY_ITEMS_COUNT,
@@ -174,8 +175,17 @@ class VectorMemoryStore(KnowledgeStore[LearningContext]):
             raise VectorStoreInitError(msg) from e
 
         try:
+            catalog_entry = resolve_model(self.config.embedding_model_name)
+        except ValueError as e:
+            raise VectorStoreInitError(str(e)) from e
+
+        self.embedding_model_stable_id = catalog_entry.stable_id
+        self.embedding_st_name = catalog_entry.st_name
+        self.embedding_dimension = catalog_entry.dimension
+
+        try:
             self.embedding_model = SentenceTransformer(
-                self.config.embedding_model_name, device=self.config.embedding_device
+                catalog_entry.st_name, device=self.config.embedding_device
             )
         except Exception as e:
             msg = ERROR_MSG_EMBEDDING_MODEL_INIT_FAILED.format(error=e)

--- a/tests/test_embedding_catalog.py
+++ b/tests/test_embedding_catalog.py
@@ -1,0 +1,52 @@
+"""Tests for memory_gate.embedding_catalog."""
+
+import pytest
+
+from memory_gate.embedding_catalog import (
+    SUPPORTED_STABLE_IDS,
+    CatalogEntry,
+    resolve_model,
+)
+
+
+class TestResolveModel:
+    def test_stable_id_bge_small(self) -> None:
+        entry = resolve_model("bge-small-en-v1.5")
+        assert entry.st_name == "BAAI/bge-small-en-v1.5"
+        assert entry.stable_id == "bge-small-en-v1.5"
+        assert entry.dimension == 384
+
+    def test_stable_id_minilm(self) -> None:
+        entry = resolve_model("all-minilm-l6-v2")
+        assert entry.st_name == "all-MiniLM-L6-v2"
+        assert entry.dimension == 384
+
+    def test_sentence_transformers_name_minilm(self) -> None:
+        entry = resolve_model("all-MiniLM-L6-v2")
+        assert entry.stable_id == "all-minilm-l6-v2"
+
+    def test_hf_prefixed_bge(self) -> None:
+        entry = resolve_model("BAAI/bge-base-en-v1.5")
+        assert entry.stable_id == "bge-base-en-v1.5"
+        assert entry.dimension == 768
+
+    def test_sentence_transformers_prefix(self) -> None:
+        entry = resolve_model("sentence-transformers/all-MiniLM-L6-v2")
+        assert entry.stable_id == "all-minilm-l6-v2"
+
+    def test_aliases(self) -> None:
+        assert resolve_model("minilm").stable_id == "all-minilm-l6-v2"
+        assert resolve_model("bge-small").stable_id == "bge-small-en-v1.5"
+        assert resolve_model("bge-base").stable_id == "bge-base-en-v1.5"
+
+    def test_unknown_lists_supported_ids(self) -> None:
+        with pytest.raises(ValueError, match="unknown embedding model"):
+            resolve_model("not-a-model")
+        with pytest.raises(ValueError) as exc_info:
+            resolve_model("not-a-model")
+        for sid in SUPPORTED_STABLE_IDS:
+            assert sid in str(exc_info.value)
+
+    def test_catalog_entry_frozen(self) -> None:
+        entry = resolve_model("all-minilm-l6-v2")
+        assert isinstance(entry, CatalogEntry)

--- a/tests/test_vector_store_unit.py
+++ b/tests/test_vector_store_unit.py
@@ -82,6 +82,40 @@ class TestVectorStoreInitFailures:
             with pytest.raises(VectorStoreInitError, match="Failed to initialize embedding model"):
                 VectorMemoryStore(config=config)
 
+    def test_unknown_embedding_model_id(self) -> None:
+        config = VectorStoreConfig(
+            collection_name="fail",
+            persist_directory=None,
+            embedding_model_name="not-a-model",
+        )
+        mock_client = MagicMock()
+        with patch(
+            "memory_gate.storage.vector_store.chromadb.Client",
+            return_value=mock_client,
+        ):
+            with pytest.raises(VectorStoreInitError, match="unknown embedding model"):
+                VectorMemoryStore(config=config)
+
+    def test_resolves_stable_id_before_sentence_transformer(self) -> None:
+        config = VectorStoreConfig(
+            collection_name="catalog_test",
+            persist_directory=None,
+            embedding_model_name="bge-small-en-v1.5",
+        )
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection.return_value = MagicMock()
+        with (
+            patch("memory_gate.storage.vector_store.chromadb.Client", return_value=mock_client),
+            patch(
+                "memory_gate.storage.vector_store.SentenceTransformer",
+            ) as mock_st,
+        ):
+            store = VectorMemoryStore(config=config)
+        mock_st.assert_called_once_with("BAAI/bge-small-en-v1.5", device="cpu")
+        assert store.embedding_model_stable_id == "bge-small-en-v1.5"
+        assert store.embedding_st_name == "BAAI/bge-small-en-v1.5"
+        assert store.embedding_dimension == 384
+
 
 @pytest.fixture
 def mocked_vector_store() -> VectorMemoryStore:

--- a/tests/test_vector_store_unit.py
+++ b/tests/test_vector_store_unit.py
@@ -71,7 +71,6 @@ class TestVectorStoreInitFailures:
     def test_embedding_model_init_failure(self) -> None:
         config = VectorStoreConfig(collection_name="fail", persist_directory=None)
         mock_client = MagicMock()
-        mock_client.get_or_create_collection.return_value = MagicMock()
         with (
             patch("memory_gate.storage.vector_store.chromadb.Client", return_value=mock_client),
             patch(
@@ -88,13 +87,10 @@ class TestVectorStoreInitFailures:
             persist_directory=None,
             embedding_model_name="not-a-model",
         )
-        mock_client = MagicMock()
-        with patch(
-            "memory_gate.storage.vector_store.chromadb.Client",
-            return_value=mock_client,
-        ):
+        with patch("memory_gate.storage.vector_store.chromadb.Client") as mock_client_cls:
             with pytest.raises(VectorStoreInitError, match="unknown embedding model"):
                 VectorMemoryStore(config=config)
+        mock_client_cls.assert_not_called()
 
     def test_resolves_stable_id_before_sentence_transformer(self) -> None:
         config = VectorStoreConfig(
@@ -102,8 +98,13 @@ class TestVectorStoreInitFailures:
             persist_directory=None,
             embedding_model_name="bge-small-en-v1.5",
         )
+        mock_collection = MagicMock()
+        mock_collection.metadata = {
+            "memory_gate_embedding_model": "bge-small-en-v1.5",
+            "memory_gate_embedding_dim": "384",
+        }
         mock_client = MagicMock()
-        mock_client.get_or_create_collection.return_value = MagicMock()
+        mock_client.get_or_create_collection.return_value = mock_collection
         with (
             patch("memory_gate.storage.vector_store.chromadb.Client", return_value=mock_client),
             patch(
@@ -117,6 +118,75 @@ class TestVectorStoreInitFailures:
         assert store.embedding_dimension == 384
 
 
+def _mock_collection_for_binding(
+    *,
+    model: str | None = None,
+    dim: str | None = None,
+    count: int = 0,
+) -> MagicMock:
+    mock_collection = MagicMock()
+    meta: dict[str, str] = {"description": "test"}
+    if model is not None:
+        meta["memory_gate_embedding_model"] = model
+    if dim is not None:
+        meta["memory_gate_embedding_dim"] = dim
+    mock_collection.metadata = meta
+    mock_collection.count.return_value = count
+    return mock_collection
+
+
+def _init_store_with_collection(
+    config: VectorStoreConfig, mock_collection: MagicMock
+) -> VectorMemoryStore:
+    mock_client = MagicMock()
+    mock_client.get_or_create_collection.return_value = mock_collection
+    with (
+        patch("memory_gate.storage.vector_store.chromadb.Client", return_value=mock_client),
+        patch("memory_gate.storage.vector_store.SentenceTransformer"),
+    ):
+        return VectorMemoryStore(config=config)
+
+
+class TestEmbeddingCollectionBinding:
+    """Chroma collection embedding model metadata enforcement."""
+
+    def test_matching_stamps_succeeds(self) -> None:
+        config = VectorStoreConfig(collection_name="bind_ok", persist_directory=None)
+        coll = _mock_collection_for_binding(
+            model="all-minilm-l6-v2", dim="384", count=10
+        )
+        store = _init_store_with_collection(config, coll)
+        coll.modify.assert_not_called()
+        assert store.embedding_model_stable_id == "all-minilm-l6-v2"
+
+    def test_mismatch_raises(self) -> None:
+        config = VectorStoreConfig(
+            collection_name="bind_bad",
+            persist_directory=None,
+            embedding_model_name="bge-small-en-v1.5",
+        )
+        coll = _mock_collection_for_binding(
+            model="all-minilm-l6-v2", dim="384", count=1
+        )
+        with pytest.raises(VectorStoreInitError, match="binding mismatch"):
+            _init_store_with_collection(config, coll)
+
+    def test_empty_unstamped_collection_gets_stamped(self) -> None:
+        config = VectorStoreConfig(collection_name="bind_stamp", persist_directory=None)
+        coll = _mock_collection_for_binding(count=0)
+        _init_store_with_collection(config, coll)
+        coll.modify.assert_called_once()
+        stamped = coll.modify.call_args.kwargs["metadata"]
+        assert stamped["memory_gate_embedding_model"] == "all-minilm-l6-v2"
+        assert stamped["memory_gate_embedding_dim"] == "384"
+
+    def test_nonempty_unstamped_raises(self) -> None:
+        config = VectorStoreConfig(collection_name="bind_legacy", persist_directory=None)
+        coll = _mock_collection_for_binding(count=3)
+        with pytest.raises(VectorStoreInitError, match="no memory_gate embedding metadata"):
+            _init_store_with_collection(config, coll)
+
+
 @pytest.fixture
 def mocked_vector_store() -> VectorMemoryStore:
     """Vector store with mocked ChromaDB and embedding model."""
@@ -124,8 +194,9 @@ def mocked_vector_store() -> VectorMemoryStore:
         collection_name="unit_test_collection",
         persist_directory=None,
     )
-    mock_collection = MagicMock()
-    mock_collection.count.return_value = 0
+    mock_collection = _mock_collection_for_binding(
+        model="all-minilm-l6-v2", dim="384", count=0
+    )
     mock_client = MagicMock()
     mock_client.get_or_create_collection.return_value = mock_collection
     mock_model = MagicMock()
@@ -159,6 +230,28 @@ class TestVectorStoreOperations:
         )
         assert context.domain == "unknown"
         assert context.content == "document body"
+
+    @pytest.mark.asyncio
+    async def test_store_strips_reserved_experience_metadata(
+        self, mocked_vector_store: VectorMemoryStore
+    ) -> None:
+        context = LearningContext(
+            content="meta strip",
+            domain="test",
+            timestamp=datetime.now(),
+            metadata={
+                "custom": "keep",
+                "memory_gate_embedding_model": "spoof",
+                "embedding_dim": "999",
+            },
+        )
+        await mocked_vector_store.store_experience("key-meta", context)
+        stored_meta = mocked_vector_store.collection.upsert.call_args.kwargs["metadatas"][
+            0
+        ]
+        assert stored_meta["custom"] == "keep"
+        assert "memory_gate_embedding_model" not in stored_meta
+        assert "embedding_dim" not in stored_meta
 
     @pytest.mark.asyncio
     async def test_store_experience_failure(


### PR DESCRIPTION
## Summary
- Adds `memory_gate.embedding_catalog` with stable IDs matching memory-gate-rs.
- `VectorMemoryStore` resolves catalog before SentenceTransformer init.
- Default remains MiniLM; supports `bge-small-en-v1.5` and `bge-base-en-v1.5`.

## Validation
- `uv run pytest --cov=src/memory_gate --cov-fail-under=85` (130 passed, ~97.7% cov)

## Non-goals
- Batch upsert / query cache (later wave)