### PR TITLE
ci: route linux jobs to self-hosted podman fleet and enable triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,12 @@
 name: Continuous Integration
 
-# Manual only — no push/pull_request CI triggers
+# Triggered on push/PR; also manual.
+# Linux x64 jobs: self-hosted Podman fleet.
 on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
   workflow_dispatch:
 jobs:
   code-quality:
@@ -46,7 +51,7 @@ jobs:
       
   ci-complete:
     name: CI Complete
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     needs: [code-quality, security, unit-tests, integration-tests, regression-tests]
     if: always()
     steps:

--- a/.github/workflows/commitizen.yml
+++ b/.github/workflows/commitizen.yml
@@ -1,7 +1,11 @@
 name: Commitizen
 
-# Commitizen CI Contract v1 — manual pre-release conventional commit verification
+# Conventional commit verification on push/PR + manual
 on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
   workflow_dispatch:
 
 permissions:
@@ -10,7 +14,7 @@ permissions:
 jobs:
   cz-check:
     name: Conventional Commits Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   lint:
     name: Code Quality Checks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     
     steps:
     - name: Checkout code

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   security:
     name: Security Checks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     outputs:
       coverage: ${{ steps.coverage.outputs.percentage }}
     


### PR DESCRIPTION
## Summary
Adapt **Python memory-gate** CI for the shared self-hosted Podman fleet and automatic triggers (parity with tero-rs / tero-mcp / memory-gate-rs).

### Changes
- All job `runs-on` → `[self-hosted, linux, x64, podman]`
- `ci.yml` + `commitizen.yml`: `push` / `pull_request` to `main`/`dev` + `workflow_dispatch`
- Reusable `lint` / `security` / `test` workflows: fleet labels only

### Register runner
Warm-list repo: `tzervas/memory-gate` (with the other stack repos).